### PR TITLE
emit types, change scripts, relocated type module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-**/*
-!/dist/**
-!README.md

--- a/demos/cjs/package.json
+++ b/demos/cjs/package.json
@@ -4,12 +4,12 @@
   "description": "CommonJS demo for console-dictation",
   "main": "demo.js",
   "scripts": {
-    "demo": "npm run prepare && node demo.js",
-    "prepare": "npm run package && npm i console-dictation-demo_pkg.tgz && npm run clean:logs",
+    "start": "node demo.js",
+    "prestart": " npm run clean:logs && npm run package && npm i console-dictation-demo_pkg.tgz",
     "package": "cd ../../ && npm pack && mv *.tgz ./demos/cjs/console-dictation-demo_pkg.tgz",
-    "clean": "npm run clean:logs && npm run clean:tar",
+    "clean": "npm run clean:logs && npm run clean:package",
     "clean:logs": "rm -rf ./logs",
-    "clean:tar": "rm -rf ./console-dictation-demo_pkg.tgz"
+    "clean:package": "rm -rf ./console-dictation-demo_pkg.tgz node_modules package-lock.json"
   },
   "author": "Eyas Valdez",
   "license": "ISC",

--- a/demos/mjs/package.json
+++ b/demos/mjs/package.json
@@ -5,12 +5,12 @@
   "main": "demo.js",
   "type": "module",
   "scripts": {
-    "demo": "npm run prepare && node demo.js",
-    "prepare": "npm run package && npm i console-dictation-demo_pkg.tgz && npm run clean:logs",
+    "start": "node demo.js",
+    "prestart": " npm run clean:logs && npm run package && npm i console-dictation-demo_pkg.tgz",
     "package": "cd ../../ && npm pack && mv *.tgz ./demos/mjs/console-dictation-demo_pkg.tgz",
-    "clean": "npm run clean:logs && npm run clean:tar",
+    "clean": "npm run clean:logs && npm run clean:package",
     "clean:logs": "rm -rf ./logs",
-    "clean:tar": "rm -rf ./console-dictation-demo_pkg.tgz"
+    "clean:package": "rm -rf ./console-dictation-demo_pkg.tgz node_modules package-lock.json"
   },
   "author": "Eyas Valdez",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -3,28 +3,27 @@
 	"version": "1.3.1",
 	"description": "A method to dictate console reports to persistent files",
 	"main": "./dist/mjs/index.mjs",
-	"types": "./dist/mjs/types/index.d.ts",
+	"types": "./dist/@types/index.d.ts",
 	"exports": {
 		".": {
-			"import": {
-				"types": "./dist/mjs/types/index.d.ts",
-				"default": "./dist/mjs/index.mjs"
-			},
-			"require": {
-				"types": "./dist/cjs/types/index.d.ts",
-				"default": "./dist/cjs/index.js"
-			}
+			"import": "./dist/mjs/index.mjs",
+			"require": "./dist/cjs/index.js"
 		}
 	},
 	"files": [
-		"dist/**/*"
+		"dist/**/*",
+		"README.MD"
 	],
 	"scripts": {
-		"clean": "rm -rf dist",
-		"build": "npm run clean && npm run build:mjs && npm run build:cjs",
+		"prebuild": "npm run clean",
+		"prepack": "npm i && npm run build",
+		"build": "npm run build:types && npm run build:mjs && npm run build:cjs",
 		"build:cjs": "tsc -p tsconfig.cjs.json",
-		"build:mjs": "rollup --bundleConfigAsCjs --config rollup.config.js",
-		"prepack": "npm i && npm run build"
+		"build:mjs": "rollup --bundleConfigAsCjs -c rollup.config.js",
+		"build:types": "tsc -p tsconfig.types.json && rollup --bundleConfigAsCjs -c rollup.types.js",
+		"postbuild:types":"npm run clean:types",		
+		"clean": "rm -rf dist",
+		"clean:types": "rm -rf dist/types"
 	},
 	"repository": {
 		"type": "git",
@@ -51,6 +50,7 @@
 		"@rollup/plugin-typescript": "^11.1.1",
 		"@types/node": "^20.2.5",
 		"rollup": "^3.24.1",
+		"rollup-plugin-dts": "^5.3.0",
 		"tslib": "^2.5.3",
 		"typescript": "^5.1.3"
 	}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,15 @@
 import typescript from '@rollup/plugin-typescript';
-
-export default {
-  input: 'src/index.ts',
-  output: {
-	file: 'dist/mjs/index.mjs',
-    format: 'es',
-	exports: "named",
-  },
-  plugins: [typescript()]
-}
+export default [
+	{
+		input: 'src/index.ts',
+		output: {
+			file: 'dist/mjs/index.mjs',
+			format: 'es',
+			exports: 'named',
+			generatedCode: {
+				constBindings: true
+			}
+		},
+		plugins: [typescript()]
+	}
+]

--- a/rollup.types.js
+++ b/rollup.types.js
@@ -1,0 +1,23 @@
+import dts from 'rollup-plugin-dts'
+export default [
+	{
+		input: './src/@types/index.d.ts',
+		output: [
+			{
+				file: 'dist/types/@types/index.d.ts',
+				format: 'es'
+			}
+		],
+		plugins: [dts.default()],
+	},
+	{
+		input: 'dist/types/index.d.ts',
+		output: [
+			{
+				file: 'dist/@types/index.d.ts',
+				format: 'es',
+			}
+		],
+		plugins: [dts.default()],
+	}
+]

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,26 +1,26 @@
-interface GenericPaths {
+export interface GenericPaths {
 	SYS?: string,
 	ERR?: string,
 	MISC?: string,
 	[log_slug: string]: string
 }
 
-interface isValidRequest extends GenericPaths { }
+export interface isValidRequest extends GenericPaths { }
 
-interface PATHS extends GenericPaths { }
+export interface Paths extends GenericPaths { }
 
-interface LOG_NAMES extends GenericPaths { }
+export interface LogNames extends GenericPaths { }
 
-interface ALIASES {
+export interface Aliases {
 	[log_slug: string]: (string | undefined)[]
 }
 
-type RequestValidatorResponse = {
+export type RequestValidatorResponse = {
 	isValid: boolean,
 	message: string
 }
 
-type IndexingConfig = {
+export type IndexingConfig = {
 	indexing: boolean,
 	dependencies: {
 		SYS?: (keyof typeof CallableWrites | undefined)[],
@@ -30,9 +30,9 @@ type IndexingConfig = {
 	}
 }
 
-interface IndexingConfigOptions {
-	paths?: PATHS,
-	log_names?: LOG_NAMES,
+export interface IndexingConfigOptions {
+	paths?: Paths,
+	log_names?: LogNames,
 	indexing_config?: {
 		indexing?: boolean,
 		dependencies?: {
@@ -41,12 +41,12 @@ interface IndexingConfigOptions {
 	}
 }
 
-interface CustomPath {
+export interface CustomPath {
 	PATH?: string,
 	LOG_NAME?: string
 }
 
-enum CallableWrites {
+export enum CallableWrites {
 	system,
 	error,
 	misc

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,11 +1,12 @@
 import path from 'path'
+import type { Paths, LogNames, IndexingConfig, Aliases } from '../@types/index'
 
-export const PATHS: PATHS = {
+export const PATHS: Paths = {
 	ERR: path.join(process.cwd(), './logs/error'),
 	MISC: path.join(process.cwd(), './logs/misc'),
 	SYS: path.join(process.cwd(), './logs/sys')
 }
-export const LOG_NAMES: LOG_NAMES = {
+export const LOG_NAMES: LogNames = {
 	ERR: 'err.log',
 	MISC: 'misc.log',
 	SYS: 'sys.log'
@@ -21,7 +22,7 @@ export const INDEXING_CONFIG: IndexingConfig = {
 	}
 }
 
-export const ALIASES: ALIASES = {
+export const ALIASES: Aliases = {
 	SYS: ['SYS', 'SYS', '0'],
 	ERR: ['ERR', 'ERR', '1'],
 	MISC: ['MISC', 'MISCELLANEOUS', '2']

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -4,6 +4,7 @@ import { getTimeStamp } from '../utils/date'
 import { isRequestValid } from '../utils/validator'
 import { tracker } from '../utils/indexer'
 import { PATHS, LOG_NAMES, INDEXING_CONFIG, ALIASES } from './config'
+import type { IndexingConfigOptions, CustomPath, CallableWrites } from '../@types/index'
 
 /*
 * ----------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import dictator from './core/main'
 
-export const {
+const {
 	config,
 	system,
 	error,
@@ -11,7 +11,8 @@ export const {
 	getPaths,
 } = dictator
 
-export default {
+export {
+	dictator as default,
 	config,
 	system,
 	error,
@@ -21,3 +22,4 @@ export default {
 	getLogNames,
 	getPaths,
 }
+export type * from './@types/index.d.ts'

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,3 +1,5 @@
+import type { isValidRequest, CustomPath, RequestValidatorResponse } from '../@types/index';
+
 const isRequestValid = (
 	request: isValidRequest | CustomPath,
 	params: string[]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,19 +1,20 @@
 {
 	"compilerOptions": {
-		"strict": true,			// catch poor code conventions
-		"allowJs": false,		// allow importing js files in your project (rather than ts/x)
+		"strict": true, // catch poor code conventions
+		"allowJs": false, // allow importing js files in your project (rather than ts/x)
 		"forceConsistentCasingInFileNames": true,
-		"skipLibCheck": true,	// checking will compare your lib types to the types you use in code
-
-		"allowSyntheticDefaultImports": true,		// sets default where none. so you can import d from '' without import * as d from ''
-		"esModuleInterop": true,	// honestly not sure, works with allowSyntheticDefaultImports
-
-		"declaration": true,	// export a d.ts file for each ts file in project
-		"declarationMap": true,	// creates a source map for the d.ts files to the original ts files. for vs code really
+		"skipLibCheck": true, // checking will compare your lib types to the types you use in code
+		"allowSyntheticDefaultImports": true, // sets default where none. so you can import d from '' without import * as d from ''
+		"esModuleInterop": true, // honestly not sure, works with allowSyntheticDefaultImports
+		"declaration": false, // export a d.ts file for each ts file in project
+		"declarationMap": false, // creates a source map for the d.ts files to the original ts files. for vs code really
 		"removeComments": true,
+		"isolatedModules": true, // warn if there is code that cannot be transpiled into single-file (useful for rollup)
+		"lib": [
+			"ESNext",
+		] // libraries to look for type definitions
 	},
 	"include": [
-		"src/*",
-		"types.d.ts"
+		"src/*"
 	]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,14 +1,9 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"target": "ES6",
-		"module": "CommonJS",
-		"lib": [
-			"DOM",
-			"ES6"
-		],
-		"moduleResolution": "node",
+		"target": "ES6",	// which JavaScript language version is emitted
+		"module": "CommonJS",	// which JavaScript module format should be used when compiling your project code
+		"moduleResolution": "node",	// module import strategy
 		"outDir": "dist/cjs",
-		"declarationDir": "dist/cjs/types"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
 	"extends": "./tsconfig.base.json",
 	"compilerOptions": {
-		"module": "ESNext", // which JavaScript module format should be used when compiling your project code
-		"outDir": "dist/mjs",
-		"declarationDir": "dist/mjs/types"
+		"target":"ESNext",	// which JavaScript language version is emitted
 	}
 }

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.base.json",
+	"compilerOptions": {
+	  "declarationDir": "./dist/types",
+	  "declaration": true,
+	  "declarationMap": true,
+	  "emitDeclarationOnly": true
+	}
+  }


### PR DESCRIPTION
features:
- moved `types.d.ts` -> `src/@types/index.d.ts`
- removed `.npmignore` because `package.json` `files` is redundant. In the future, use `package.json` for whitelisting and `.npmignore` for blacklisting.
- added scripts to separate build logic for packaging. Notably the `build:type` step.
- added demo scripts using `npm start` utilizing `prestart`.
- moved `package.json` `export.*.types` to the top layer. This is because on the type bundling step, the type declarations are shared so it would be redundant to export the same path for `import` and `require` in `package.json`.
- added `constBindings` to `rollup.config.js` to have const preferences on bundle.
- added the type declaration bundle step with `rollup-plugin-dts` and fixes #12 :
1. use tsc transpiler to emit types for source code.
2. use rollup to bundle the type module in `src/@types`
3. use rollup to bundle (1) and (2) into `dist/@types/index.d.ts`
- add `export * 'path_to_types'` in `index.ts` so that the type declaration bundle step worked. This is because the tsc emitted types are used as the `input` point, so the (3) step wouldn't recognize that the module types in `src/@types` needed to be exported unless the source code `index.ts` file exported the types.
- added `tsconfig.types.json` to complete step (1).
- added `rollup.types.js` to complete steps (2) and (3).
- changed `declaration/Map` to false in `tsconfig.base.json` because done in a different step.
- added `isolatedModules` and `lib` to `tsconfig.base.json`. `lib` should be a shared declaration library and `isolatedModules` should be a good flag for the esm bundling strategy.
- removed `outDir` and `declarationDir` from `tsconfig.json` because bundling and type bundling are done using rollup in a different step.
- added exports to the type module so they would be exported in the bundle step. Because of this change, the `*.ts` files had to import the necessary types. Maybe test declares instead of export in the future.
- replaced double export line in index.ts (i.e., export {}; export default {}) with single export and defined default (i.e., export { d as default, ...})